### PR TITLE
adjusted to display markdown with more @the-blue

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -7,14 +7,15 @@
 @brown-gray: #49483E;
 @dark-gray: #282828;
 
-@yellow: #E6DB74;
 @blue: #66D9EF;
 @pink: #FF5D5B;
-@purple: #AE81FF;
 @brown: #75715E;
 @orange: #FD971F;
 @light-orange: #FFD569;
-@green: #A6E22E;
 @sea-green: #529B2F;
 @the-blue: #42B3FF;
+@green: @the-blue;
+@purple: @the-blue;
+@yellow: @the-blue;
 @the-black: rgba(0,0,0,0.4);
+


### PR DESCRIPTION
I don't know if I did any of this right, but I thought it was annoying that my markdown files still looked like monokai
